### PR TITLE
Improve widget theming in GUI

### DIFF
--- a/gui/panels/panel_cipher.py
+++ b/gui/panels/panel_cipher.py
@@ -31,11 +31,30 @@ class CipherPanel(ttk.Frame):
         ttk.Entry(self, textvariable=self.pass_var, show="*").grid(row=1, column=1, columnspan=2, sticky="ew")
 
         ttk.Label(self, text="Input:").grid(row=2, column=0, padx=10, pady=5)
-        self.input_text = tk.Text(self, height=4, width=40)
+
+        style = ttk.Style()
+        text_bg = style.lookup("TEntry", "fieldbackground")
+        text_fg = style.lookup("TEntry", "foreground")
+
+        self.input_text = tk.Text(
+            self,
+            height=4,
+            width=40,
+            bg=text_bg,
+            fg=text_fg,
+            insertbackground=text_fg,
+        )
         self.input_text.grid(row=2, column=1, columnspan=2, pady=5, sticky="ew")
 
         ttk.Label(self, text="Output:").grid(row=3, column=0, padx=10, pady=5)
-        self.output_text = tk.Text(self, height=4, width=40)
+        self.output_text = tk.Text(
+            self,
+            height=4,
+            width=40,
+            bg=text_bg,
+            fg=text_fg,
+            insertbackground=text_fg,
+        )
         self.output_text.grid(row=3, column=1, columnspan=2, pady=5, sticky="ew")
 
         ttk.Button(self, text="Encrypt", command=self.encrypt).grid(row=4, column=1, pady=5)

--- a/gui/panels/panel_settings.py
+++ b/gui/panels/panel_settings.py
@@ -17,8 +17,31 @@ class SettingsPanel(ttk.Frame):
         ttk.Label(self, text="Theme:").grid(row=0, column=0, pady=10, padx=10)
 
         self.theme_var = tk.StringVar(value=list(self.themes.keys())[0])
+
+        # derive combobox colors from current ttk style
+        style = ttk.Style()
+        dd_bg = style.lookup("TCombobox", "fieldbackground")
+        dd_fg = style.lookup("TCombobox", "foreground")
+
+        style.configure(
+            "Settings.TCombobox",
+            fieldbackground=dd_bg,
+            background=dd_bg,
+            foreground=dd_fg,
+        )
+        style.map(
+            "Settings.TCombobox",
+            fieldbackground=[("readonly", dd_bg)],
+            background=[("readonly", dd_bg)],
+            foreground=[("readonly", dd_fg)],
+        )
+
         self.theme_combo = ttk.Combobox(
-            self, textvariable=self.theme_var, values=list(self.themes.keys()), state="readonly"
+            self,
+            textvariable=self.theme_var,
+            values=list(self.themes.keys()),
+            state="readonly",
+            style="Settings.TCombobox",
         )
         self.theme_combo.grid(row=0, column=1, padx=10)
 


### PR DESCRIPTION
## Summary
- style settings combobox with theme colors
- color cipher panel text widgets using theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503d5827c083258f5e5da723b4c884